### PR TITLE
Fixed some blockstate names

### DIFF
--- a/src/main/resources/assets/hearthandharvest/blockstates/green_grapes.json
+++ b/src/main/resources/assets/hearthandharvest/blockstates/green_grapes.json
@@ -13,7 +13,7 @@
       "model": "hearthandharvest:block/green_grapes_stage3"
     },
     "age=0,ropelogged=true": {
-      "model": "hearthandharvest:block/grapes_vine_stage0"
+      "model": "hearthandharvest:block/green_grapes_vine_stage0"
     },
     "age=1,ropelogged=true": {
       "model": "hearthandharvest:block/green_grapes_vine_stage1"

--- a/src/main/resources/assets/hearthandharvest/blockstates/red_grapes.json
+++ b/src/main/resources/assets/hearthandharvest/blockstates/red_grapes.json
@@ -13,7 +13,7 @@
       "model": "hearthandharvest:block/red_grapes_stage3"
     },
     "age=0,ropelogged=true": {
-      "model": "hearthandharvest:block/grapes_vine_stage0"
+      "model": "hearthandharvest:block/green_grapes_vine_stage0"
     },
     "age=1,ropelogged=true": {
       "model": "hearthandharvest:block/red_grapes_vine_stage1"


### PR DESCRIPTION
I noticed that grapes weren't displaying textures when at 0% growth, and I was able to fix the issue after finding some mislabeled blockstate model names in the jsons. idk if it was intended to use "green_grapes_vine_stage0" for both grape types but I just stuck with the green variant of the model so its consistent with what was already there. I believe this is an issue is present in the other branches too. 

Before:
![image](https://github.com/user-attachments/assets/1463ff27-3657-40b9-9f0b-8647ce43dc34)
After:
![image](https://github.com/user-attachments/assets/e9627d6b-b2f0-4b76-92ba-7aa925751459)
*Screenshots from the 1.20.1 version