### PR TITLE
Implement stats for corn as a horse food

### DIFF
--- a/src/main/java/alabaster/hearthandharvest/common/mixin/AbstractHorseMixin.java
+++ b/src/main/java/alabaster/hearthandharvest/common/mixin/AbstractHorseMixin.java
@@ -1,0 +1,26 @@
+package alabaster.hearthandharvest.common.mixin;
+
+import alabaster.hearthandharvest.common.registry.HHModItems;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.ref.LocalFloatRef;
+import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
+import net.minecraft.world.entity.animal.horse.AbstractHorse;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(AbstractHorse.class)
+public class AbstractHorseMixin {
+
+    @Inject(method = "handleEating", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;is(Lnet/minecraft/world/item/Item;)Z", ordinal = 0))
+    private void handleEatingMixin(Player player, ItemStack stack, CallbackInfoReturnable<Boolean> cir, @Local LocalFloatRef amountHealed, @Local(ordinal = 0) LocalIntRef secondsAged, @Local(ordinal = 1) LocalIntRef temperAdded) {
+        if (stack.is(HHModItems.CORN.get())) {
+            amountHealed.set(2.0F);
+            secondsAged.set(20);
+            temperAdded.set(3);
+        }
+    }
+}

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -12,6 +12,9 @@ authors="${mod_authors}"
 description='''${mod_description}'''
 enumExtensions="META-INF/enumextensions.json"
 
+[[mixins]]
+config = "hearthandharvest.mixins.json"
+
 [[dependencies.${mod_id}]]
 modId="neoforge"
 type="required"

--- a/src/main/resources/hearthandharvest.mixins.json
+++ b/src/main/resources/hearthandharvest.mixins.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "alabaster.hearthandharvest.common.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "refmap": "hearthandharvest.refmap.json",
+  "mixins": [
+    "AbstractHorseMixin"
+  ],
+  "client": [],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
This implementation uses a single ``mixin`` that targets the ``handleEating`` boolean method in  ``AbstractHorse``. Since mixins were not previously setup I've had to make an addition to your ``neoforge.mods.toml`` file specifying the name of the ``mixin`` config used, alongside the addition of said config file: ``hearthandharvest.mixins.json``.